### PR TITLE
docs: Invar ingot alloy requires 3 iron ingots

### DIFF
--- a/docs/items/ingots/invar_ingot.mdx
+++ b/docs/items/ingots/invar_ingot.mdx
@@ -15,7 +15,7 @@ title: Invar Ingot
 
 <Machine recipe="input techreborn:invar_dust output techreborn:invar_ingot tool minecraft:furnace" />
 
-<Machine config={{input: [{id: "minecraft:iron_ingot", qty: 2}, {id: "techreborn:nickel_ingot"}], output: [{id: "techreborn:invar_ingot", qty: 3}], tool: "techreborn:alloy_smelter"}} />
+<Machine config={{input: [{id: "minecraft:iron_ingot", qty: 3}, {id: "techreborn:nickel_ingot"}], output: [{id: "techreborn:invar_ingot", qty: 3}], tool: "techreborn:alloy_smelter"}} />
 
 ## Usage
 


### PR DESCRIPTION
A minor edit to the docs as invar ingots actually require *3* iron ingots and 1 nickel, not *2* iron ingots